### PR TITLE
Update property decorators to use correct types

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/clock-element.ts
+++ b/src/main/resources/META-INF/resources/frontend/clock-element.ts
@@ -8,12 +8,11 @@ import {property, customElement} from 'lit/decorators.js';
 @customElement('clock-element')
 export class ClockElement extends LitElement {
 
-    @property() showSeconds : boolean = true;
+    @property({ type: Boolean }) showSeconds = true;
 
-    @property() format12h : boolean = false;
+    @property({ type: Boolean }) format12h = false;
 
-    @property() updateInterval : number = 0;
-
+    @property({ type: Number }) updateInterval = 0;
 
     // Formatted strings of current time
     private _hours: string = "";


### PR DESCRIPTION
## Description

1. Added missing type to `@property` decorators - see [Lit documentation](https://lit.dev/docs/components/properties/#property-options);
2. Removed `boolean` and `number` since TypeScript detect the type itself.

## Type of change

- Refactor