### PR TITLE
test: fix production mode tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>Clock widget example for Vaadin</description>
 
     <properties>
-        <vaadin.version>23.2.4</vaadin.version>
+        <vaadin.version>23.3.16</vaadin.version>
 
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -298,6 +298,11 @@
             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-core</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
                     <artifactId>flow-server-production-mode</artifactId>
                 </dependency>
             </dependencies>
@@ -329,6 +334,9 @@
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
                         <configuration>
+                            <httpConnector>
+                                <port>8099</port>
+                            </httpConnector>
                             <useTestScope>true</useTestScope>
                             <stopKey>stop-it</stopKey>
                             <stopPort>8098</stopPort>

--- a/src/test/java/org/vaadin/addons/sample/AbstractTestBenchIntegrationTest.java
+++ b/src/test/java/org/vaadin/addons/sample/AbstractTestBenchIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -17,6 +18,7 @@ import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
 import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchTestCase;
+import com.vaadin.testbench.parallel.ParallelTest;
 
 /**
  * Base class for ITs
@@ -32,7 +34,7 @@ import com.vaadin.testbench.TestBenchTestCase;
  * To learn more about TestBench, visit
  * <a href="https://vaadin.com/docs/v10/testbench/testbench-overview.html">Vaadin TestBench</a>.
  */
-public abstract class AbstractTestBenchIntegrationTest extends TestBenchTestCase {
+public abstract class AbstractTestBenchIntegrationTest extends ParallelTest {
     private static final int COMPONENT_DEV_SERVER_PORT = 8099;
 
     private final String route;
@@ -103,9 +105,14 @@ public abstract class AbstractTestBenchIntegrationTest extends TestBenchTestCase
 
     @Before
     public void setup() throws Exception {
-        ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless=new", "--disable-gpu");
-        setDriver(TestBench.createDriver(new ChromeDriver(options)));
+        if (isUsingHub()) {
+            super.setup();
+        } else {
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments("--headless=new", "--disable-gpu");
+
+            setDriver(TestBench.createDriver(new ChromeDriver(options)));
+        }
         getDriver().get(getURL(route));
 
         // We do screenshot testing, adjust settings to ensure less flakiness

--- a/src/test/java/org/vaadin/addons/sample/AbstractTestBenchIntegrationTest.java
+++ b/src/test/java/org/vaadin/addons/sample/AbstractTestBenchIntegrationTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractTestBenchIntegrationTest extends TestBenchTestCase
     @Before
     public void setup() throws Exception {
         ChromeOptions options = new ChromeOptions();
-        options.setHeadless(true);
+        options.addArguments("--headless=new", "--disable-gpu");
         setDriver(TestBench.createDriver(new ChromeDriver(options)));
         getDriver().get(getURL(route));
 


### PR DESCRIPTION
Fixes maven configuration to correctly build the production bundle and to run jetty on the port expected by tests.
Also bumps Vaadin to 23.3